### PR TITLE
Fix member access precedence

### DIFF
--- a/src/nanoweave/ast/lambda.clj
+++ b/src/nanoweave/ast/lambda.clj
@@ -40,8 +40,9 @@
   FunCall
   (resolve-value [this input]
     (let [target (safe-resolve-value (:target this) input)
-          args (safe-resolve-value (:args this) input)]
+          raw-args (safe-resolve-value (:args this) input)
+          args (if (seq? raw-args) raw-args [raw-args])] ; TODO: Find a more idiomatic way to do this
       (cond
         (fn? target) (apply target args)
         (instance? java.lang.Class target) (j/call-java-constructor target args)
-        :else (throw (Exception. (str "Not sure how to call [" (type target) "]")))))))
+        :else (throw (Exception. (str "Not sure how to call [" target "]")))))))

--- a/src/nanoweave/ast/literals.clj
+++ b/src/nanoweave/ast/literals.clj
@@ -30,4 +30,4 @@
   (resolve-value [_ _] nil)
   ArrayLit
   (resolve-value [this input]
-    (map #(safe-resolve-value %1 input) (:value this))))
+    (into [] (map #(safe-resolve-value %1 input) (:value this)))))

--- a/src/nanoweave/ast/scope.clj
+++ b/src/nanoweave/ast/scope.clj
@@ -28,7 +28,7 @@
   Indexing
   (resolve-value [this input]
     (let [target (safe-resolve-value (:target this) input)
-          key (safe-resolve-value (:key this) input)]
+          key (first (safe-resolve-value (:key this) input))]
       (cond
         (map? target) (target key)
         (string? target) (str (nth target key))

--- a/src/nanoweave/core.clj
+++ b/src/nanoweave/core.clj
@@ -20,11 +20,11 @@
 (defn usage
   [options-summary]
   (->>
-    ["Performs actions on an input file according to a given nanoweave definition file."
-     "" "Usage: nanoweave [options] transform" "" "Options:" options-summary ""
-     "Actions:" "  transform\tTransforms the given input file"
-     "dump-ast\tDumps the nweave AST to a file" ""]
-    (string/join \newline)))
+   ["Performs actions on an input file according to a given nanoweave definition file."
+    "" "Usage: nanoweave [options] transform" "" "Options:" options-summary ""
+    "Actions:" "  transform\tTransforms the given input file"
+    "dump-ast\tDumps the nweave AST to a file" ""]
+   (string/join \newline)))
 
 (defn error-msg
   [errors]

--- a/src/nanoweave/diagnostics/ast_dumper.clj
+++ b/src/nanoweave/diagnostics/ast_dumper.clj
@@ -1,14 +1,14 @@
 (ns
-  ^{:doc "AST dumper diagnostic tool.", :author "Sean Dawson"}
-  nanoweave.diagnostics.ast-dumper
+ ^{:doc "AST dumper diagnostic tool.", :author "Sean Dawson"}
+ nanoweave.diagnostics.ast-dumper
   (:use
-    [rhizome.viz]
-    [nanoweave.ast.base]
-    [nanoweave.ast.literals])
+   [rhizome.viz]
+   [nanoweave.ast.base]
+   [nanoweave.ast.literals])
   (:require
-    [nanoweave.utils :refer [read-json-with-doubles]]
-    [nanoweave.parser.parser :as parser]
-    [clojure.pprint :as pp])
+   [nanoweave.utils :refer [read-json-with-doubles]]
+   [nanoweave.parser.parser :as parser]
+   [clojure.pprint :as pp])
   (:import (nanoweave.ast.literals StringLit FloatLit BoolLit NilLit ArrayLit)))
 
 (defn- primative-lit? [val]
@@ -28,14 +28,14 @@
 (defn- describe-node [node]
   {:label (if (map? node) (cond
                             (primative-lit? node) (:value node)
-                            :else (type node)
-                            ) (type node))})
+                            :else (type node))
+              (cond (instance? java.lang.String node) node
+                    :else (type node)))})
 
 (defn- describe-edge [src, dest]
   {:label (cond (map? src) (first
-                             (map (fn [[k _]] k)
-                                  (filter (fn [[_ v]] (= v dest)) src))
-                             )
+                            (map (fn [[k _]] k)
+                                 (filter (fn [[_ v]] (= v dest)) src)))
                 (vector? src)
                 (.indexOf src dest))})
 

--- a/src/nanoweave/parser/custom_lexing.clj
+++ b/src/nanoweave/parser/custom_lexing.clj
@@ -1,5 +1,5 @@
 (ns ^{:doc "Custom lexers to help with parsing.", :author "Sean Dawson"}
-nanoweave.parser.custom-lexing
+ nanoweave.parser.custom-lexing
   (:use [blancas.kern.core]
         [blancas.kern.expr]
         [blancas.kern.lexer.java-style]))
@@ -10,24 +10,24 @@ nanoweave.parser.custom-lexing
 (def space-ascii 32)
 
 (def- esc-oct
-      "Parses an octal escape code; the result is the encoded char."
-      (>>= (<+> (many1 oct-digit))
-           (fn [x]
-             (let [n (Integer/parseInt x 8)]
-               (if (<= n 0377)
-                 (return (char n))
-                 (fail "bad octal sequence"))))))
+  "Parses an octal escape code; the result is the encoded char."
+  (>>= (<+> (many1 oct-digit))
+       (fn [x]
+         (let [n (Integer/parseInt x 8)]
+           (if (<= n 0377)
+             (return (char n))
+             (fail "bad octal sequence"))))))
 
 (def- esc-char
-      "Parses an escape code for a basic char."
-      (let [codes (zipmap "btnfr'\"\\/" "\b\t\n\f\r'\"\\/")]
-        (>>= (<?> (one-of* "btnfr'\"\\/") "escape character")
-             (fn [x] (return (get codes x))))))
+  "Parses an escape code for a basic char."
+  (let [codes (zipmap "btnfr'\"\\/" "\b\t\n\f\r'\"\\/")]
+    (>>= (<?> (one-of* "btnfr'\"\\/") "escape character")
+         (fn [x] (return (get codes x))))))
 
 (def- esc-uni
-      "Parses a unicode escape code; the result is the encoded char."
-      (>>= (<+> (>> (sym* \u) (times 4 hex-digit)))
-           (fn [x] (return (aget (Character/toChars (Integer/parseInt x 16)) 0)))))
+  "Parses a unicode escape code; the result is the encoded char."
+  (>>= (<+> (>> (sym* \u) (times 4 hex-digit)))
+       (fn [x] (return (aget (Character/toChars (Integer/parseInt x 16)) 0)))))
 
 (defn string-char
   "Parses an unquoted Java character literal. Characters in terminators must be escaped."

--- a/src/nanoweave/parser/errors.clj
+++ b/src/nanoweave/parser/errors.clj
@@ -1,6 +1,6 @@
 (ns
-  ^{:doc "Error handling functions.", :author "Sean Dawson"}
-  nanoweave.parser.errors
+ ^{:doc "Error handling functions.", :author "Sean Dawson"}
+ nanoweave.parser.errors
   (:require [blancas.kern.core :refer :all]
             [blancas.kern.i18n :refer :all]
             [clojure.string :refer [join]]))
@@ -18,21 +18,17 @@
   "Makes a message of type err-system."
   [pos text] (->PError pos (list (->PMessage err-system text))))
 
-
 (defn- make-err-unexpect
   "Makes a message of type err-unexpect."
   [pos text] (->PError pos (list (->PMessage err-unexpect text))))
-
 
 (defn- make-err-expect
   "Makes a message of type err-expect."
   [pos text] (->PError pos (list (->PMessage err-expect text))))
 
-
 (defn- make-err-message
   "Makes a message of type err-message."
   [pos text] (->PError pos (list (->PMessage err-message text))))
-
 
 (defn- get-msg
   "Get the text from message types system, unexpect, and message."
@@ -42,7 +38,6 @@
     (cond (= type err-system) (fmt :unexpected text)
           (= type err-unexpect) (fmt :unexpected text)
           (= type err-message) text)))
-
 
 (defn- get-msg-expect
   "Get the text from a list of messages of type expect."
@@ -55,21 +50,19 @@
         cnt (count opts)]
     (fmt :expecting (if (= cnt 1) (first opts) (show opts)))))
 
-
 (defn- get-msg-list
   "Gets the text of error messages as a list."
   [{msgs :msgs}]
   (let [ms (distinct msgs)]
     (concat
-      (let [lst (filter #(= (:type %) err-system) ms)]
-        (reduce #(conj %1 (get-msg %2)) [] lst))
-      (let [lst (filter #(= (:type %) err-unexpect) ms)]
-        (reduce #(conj %1 (get-msg %2)) [] lst))
-      (let [lst (filter #(= (:type %) err-expect) ms)]
-        (if (empty? lst) lst (list (get-msg-expect lst))))
-      (let [lst (filter #(= (:type %) err-message) ms)]
-        (reduce #(conj %1 (get-msg %2)) [] lst)))))
-
+     (let [lst (filter #(= (:type %) err-system) ms)]
+       (reduce #(conj %1 (get-msg %2)) [] lst))
+     (let [lst (filter #(= (:type %) err-unexpect) ms)]
+       (reduce #(conj %1 (get-msg %2)) [] lst))
+     (let [lst (filter #(= (:type %) err-expect) ms)]
+       (if (empty? lst) lst (list (get-msg-expect lst))))
+     (let [lst (filter #(= (:type %) err-message) ms)]
+       (reduce #(conj %1 (get-msg %2)) [] lst)))))
 
 (defn- get-msg-str
   "Gets the text of error messages separated by \\n."

--- a/test/resources/test-fixtures/java-interop/output.json
+++ b/test/resources/test-fixtures/java-interop/output.json
@@ -3,5 +3,5 @@
   "args": "a",
   "noargs": "should be lower case",
   "static": [0, 1, 2],
-  "args constructor": "2 Mar 1901 18:05:06 GMT"
+  "precedence": "gregory"
 }

--- a/test/resources/test-fixtures/java-interop/transform.nweave
+++ b/test/resources/test-fixtures/java-interop/transform.nweave
@@ -3,5 +3,9 @@ let javaString = import "java.lang.String": {
   "noargs constructor": javaString().length(),
   "args": "a,b,c".split(",")[0],
   "static": (import "java.util.Arrays").asList([0, 1, 2]),
-  "args constructor": (import "java.util.Date")(1, 2, 3, 4, 5, 6).toGMTString()
+  "precedence": let String = import "java.lang.String",
+    Calendar = import "java.util.Calendar",
+    TimeZone = import "java.util.TimeZone",
+    Locale = import "java.util.Locale",
+    timeZone = TimeZone.getTimeZone("GMT"): Calendar.getInstance(timeZone, Locale.US).getCalendarType()
 }


### PR DESCRIPTION
- It seems that function calling and indexing needs to be implemented as
an operator so that it plays nicely with the other operators.
- Calling a function (or indexing) is techincally a binary operator
where the left side is the target and the right side is the arguments.
However, there is not usually a binary operator assigned to these
concepts. The way that I have got the parsing to work is to use
look-ahead to find the start token for a function call or index and then
pretend that it was a binary operator.
- I should probably ask someone more knowledgeable than me if this is an
efficient or idiomatic way to do this.